### PR TITLE
Update FacebookCreative to support variations

### DIFF
--- a/src/PaperG/FirehoundBlob/ScenarioValidators/UnmanagedFacebookValidator.php
+++ b/src/PaperG/FirehoundBlob/ScenarioValidators/UnmanagedFacebookValidator.php
@@ -35,9 +35,19 @@ class UnmanagedFacebookValidator implements ScenarioValidator
             $validationResult = false;
         }
 
-        $creative = $facebookBlob->getCreative();
-        if (empty($creative) || !$creative->isValid()) {
-            $validationMessage .= "Blob doesn't contain creative or the creative is not valid. ";
+        $creatives = $facebookBlob->getCreatives();
+        $isValid = true;
+        if (!empty($creatives)) {
+            foreach ($creatives as $creative) {
+                if (!$creative->isValid()) {
+                    $isValid = false;
+                    break;
+                }
+            }
+        }
+
+        if (empty($creatives) || !$isValid) {
+            $validationMessage .= "Blob doesn't contain any creative or the creatives are not valid. ";
             $validationResult = false;
         }
 
@@ -62,9 +72,19 @@ class UnmanagedFacebookValidator implements ScenarioValidator
             $validationResult = false;
         }
 
-        $creative = $facebookBlob->getCreative();
-        if (!empty($creative) && !$creative->isValid()) {
-            $validationMessage .= "Blob doesn't contain creative or the creative is not valid. ";
+        $creatives = $facebookBlob->getCreatives();
+        $isValid = true;
+        if (!empty($creatives)) {
+            foreach ($creatives as $creative) {
+                if (!$creative->isValid()) {
+                    $isValid = false;
+                    break;
+                }
+            }
+        }
+
+        if (!$isValid) {
+            $validationMessage .= "Blob doesn't contain any creative or the creatives are not valid. ";
             $validationResult = false;
         }
 

--- a/test/phpunit/src/PaperG/FirehoundBlob/Facebook/FacebookCreativeTest.php
+++ b/test/phpunit/src/PaperG/FirehoundBlob/Facebook/FacebookCreativeTest.php
@@ -26,7 +26,27 @@ class FacebookCreativeTest extends \FirehoundBlobTestCase
         $mockCreativeData->setName($mockName);
 
         $this->sut->setType($mockType);
-        $this->sut->setObjects([$mockCreativeData]);
+        $this->sut->setPrimary($mockCreativeData);
+
+        $array = $this->sut->toArray();
+        $newObject = new FacebookCreative($array);
+        $this->assertEquals($this->sut, $newObject);
+    }
+
+    public function testToFromArray_WithChildAttachments()
+    {
+        $mockType = "mock type";
+        $mockName = "mockName";
+        $mockCreativeData = new FacebookCreativeData();
+        $mockCreativeData->setName($mockName);
+
+        $mockChildName = "mockNameChild";
+        $mockCreativeDataAttachment = new FacebookCreativeData();
+        $mockCreativeDataAttachment->setName($mockChildName);
+
+        $this->sut->setType($mockType);
+        $this->sut->setPrimary($mockCreativeData);
+        $this->sut->setChildAttachments([$mockCreativeDataAttachment]);
 
         $array = $this->sut->toArray();
         $newObject = new FacebookCreative($array);
@@ -36,16 +56,24 @@ class FacebookCreativeTest extends \FirehoundBlobTestCase
     public function test_isValid_WithValidType_ReturnsTrue()
     {
         $dummyType = 'link';
+        $mockName = "mockName";
+        $mockCreativeData = new FacebookCreativeData();
+        $mockCreativeData->setName($mockName);
         $this->sut->setType($dummyType);
-        $this->sut->setObjects([1,2,3,4]);
+        $this->sut->setPrimary($mockCreativeData);
         $this->assertEquals(true, $this->sut->isValid());
     }
 
     public function test_isValid_WithInvalidType_ReturnsFalse()
     {
         $dummyType = 'some_link_no_one_knows';
+        $mockName = "mockName";
+        $mockCreativeData = new FacebookCreativeData();
+        $mockCreativeData->setName($mockName);
         $this->sut->setType($dummyType);
-        $this->sut->setObjects([1,2,3,4]);
+        $this->sut->setPrimary($mockCreativeData);
         $this->assertEquals(false, $this->sut->isValid());
     }
-} 
+
+
+}

--- a/test/phpunit/src/PaperG/FirehoundBlob/Facebook/UnmanagedFacebookBlobTest.php
+++ b/test/phpunit/src/PaperG/FirehoundBlob/Facebook/UnmanagedFacebookBlobTest.php
@@ -46,4 +46,4 @@ class UnmanagedFacebookBlobTest extends \FirehoundBlobTestCase
 
         $this->assertEquals($this->sut, $new);
     }
-} 
+}

--- a/test/phpunit/src/PaperG/FirehoundBlob/ScenarioValidators/UnmanagedFacebookValidatorTest.php
+++ b/test/phpunit/src/PaperG/FirehoundBlob/ScenarioValidators/UnmanagedFacebookValidatorTest.php
@@ -52,8 +52,8 @@ class UnmanagedFacebookValidatorTest extends \PHPUnit_Framework_TestCase
                             ->method('getStatus')
                             ->will($this->returnValue('active'));
         $mockUnmanagedFbBlob->expects($this->once())
-                            ->method('getCreative')
-                            ->will($this->returnValue($mockCreative));
+                            ->method('getCreatives')
+                            ->will($this->returnValue([$mockCreative]));
         $mockUnmanagedFbBlob->expects($this->once())
                             ->method('getAdSets')
                             ->will($this->returnValue([$mockAdSet]));
@@ -94,8 +94,8 @@ class UnmanagedFacebookValidatorTest extends \PHPUnit_Framework_TestCase
                             ->method('getStatus')
                             ->will($this->returnValue(''));
         $mockUnmanagedFbBlob->expects($this->once())
-                            ->method('getCreative')
-                            ->will($this->returnValue($mockCreative));
+                            ->method('getCreatives')
+                            ->will($this->returnValue([$mockCreative]));
         $mockUnmanagedFbBlob->expects($this->once())
                             ->method('getAdSets')
                             ->will($this->returnValue([$mockAdSet]));
@@ -140,8 +140,8 @@ class UnmanagedFacebookValidatorTest extends \PHPUnit_Framework_TestCase
                             ->method('getStatus')
                             ->will($this->returnValue(''));
         $mockUnmanagedFbBlob->expects($this->once())
-                            ->method('getCreative')
-                            ->will($this->returnValue($mockCreative));
+                            ->method('getCreatives')
+                            ->will($this->returnValue([$mockCreative]));
         $mockUnmanagedFbBlob->expects($this->once())
                             ->method('getAdSets')
                             ->will($this->returnValue([$mockAdSet]));


### PR DESCRIPTION
Updated FacebookCreative class with two fields: child_attachments and primary. These two fields will be used to support variations.

Removed the previous "objects" field.