### PR TITLE
UnmanagedFacebookBlob::fromArray bug fix

### DIFF
--- a/src/PaperG/FirehoundBlob/Facebook/UnmanagedFacebookBlob.php
+++ b/src/PaperG/FirehoundBlob/Facebook/UnmanagedFacebookBlob.php
@@ -381,12 +381,12 @@ class UnmanagedFacebookBlob implements BlobInterface
         $this->accessToken          = $this->safeGet($array, self::ACCESS_TOKEN);
 
         $creatives = $this->safeGet($array, self::CREATIVES, []);
+        $this->creatives = [];
         foreach ($creatives as $creative) {
             $fbCreative = new FacebookCreative();
             $fbCreative->fromArray($creative);
-            $creatives[] = $fbCreative;
+            $this->creatives[] = $fbCreative;
         }
-        $this->creatives = $creatives;
 
         $adSetResults               = [];
         $adSets                     = $this->safeGet($array, self::AD_SETS, []);

--- a/test/phpunit/src/PaperG/FirehoundBlob/Facebook/UnmanagedFacebookBlobTest.php
+++ b/test/phpunit/src/PaperG/FirehoundBlob/Facebook/UnmanagedFacebookBlobTest.php
@@ -9,6 +9,8 @@
 namespace PaperG\Common\Test\Facebook;
 
 
+use PaperG\FirehoundBlob\Facebook\FacebookCreative;
+use PaperG\FirehoundBlob\Facebook\FacebookCreativeData;
 use PaperG\FirehoundBlob\Facebook\UnmanagedFacebookBlob;
 
 class UnmanagedFacebookBlobTest extends \FirehoundBlobTestCase
@@ -31,6 +33,22 @@ class UnmanagedFacebookBlobTest extends \FirehoundBlobTestCase
         $mockAdAccountId = "ad account";
         $mockPageId = "page id";
         $mockAccessToken  = "mock access token";
+        $mockType = 'mock type';
+        $mockMediaUrl = 'mock media url';
+        $mockPrimary = [
+            FacebookCreativeData::MEDIA_URL => $mockMediaUrl,
+            FacebookCreativeData::VERSION => FacebookCreativeData::CURRENT_VERSION
+        ];
+
+        $mockFacebookCreative = $this->buildMock('PaperG\FirehoundBlob\Facebook\FacebookCreative');
+        $mockArray = [
+            FacebookCreative::TYPE => $mockType,
+            FacebookCreative::VERSION => FacebookCreative::CURRENT_VERSION,
+            FacebookCreative::PRIMARY => $mockPrimary,
+            FacebookCreative::CHILD_ATTACHMENTS => []
+        ];
+        $this->addExpectation($mockFacebookCreative, $this->once(), 'toArray', null, $mockArray);
+        $mockCreatives = [$mockFacebookCreative];
         $this->sut->setStatus($mockStatus);
         $this->sut->setStartDate($mockStart);
         $this->sut->setEndDate($mockEnd);
@@ -38,12 +56,18 @@ class UnmanagedFacebookBlobTest extends \FirehoundBlobTestCase
         $this->sut->setAdAccountId($mockAdAccountId);
         $this->sut->setPageId($mockPageId);
         $this->sut->setAccessToken($mockAccessToken);
+        $this->sut->setCreatives($mockCreatives);
 
         $array  = $this->sut->toArray();
 
         $new = new UnmanagedFacebookBlob();
         $new->fromArray($array);
-
+        $creatives = $new->getCreatives();
+        $this->sut->setCreatives([]);
+        $new->setCreatives([]);
         $this->assertEquals($this->sut, $new);
+
+        $this->assertEquals($mockMediaUrl, $creatives[0]->getPrimary()->getMediaUrl());
+        $this->assertEquals($mockType, $creatives[0]->getType());
     }
 }


### PR DESCRIPTION
This commit fixes a bug where UnmanagedFacebookBlob creatives were a mix
of FacebookCreative and arrays

PL-20876