### PR TITLE
Add Callbacks to UnmanagedDcmBlob

### DIFF
--- a/src/PaperG/FirehoundBlob/Dcm/UnmanagedDcmBlob.php
+++ b/src/PaperG/FirehoundBlob/Dcm/UnmanagedDcmBlob.php
@@ -13,6 +13,8 @@ class UnmanagedDcmBlob implements BlobInterface
     const PUBLICATION_ID = 'publicationId';
     const GOOGLE_ADVERTISER_ID = 'googleAdvertiserId';
     const CREATIVE_ASSETS = 'creativeAssets';
+    const STATUS_CALLBACK_URL = 'callbackUrl';
+    const STATUS_CALLBACK_HEADERS = 'callbackHeaders';
 
     /**
      * @var int
@@ -29,6 +31,10 @@ class UnmanagedDcmBlob implements BlobInterface
      */
     private $creativeAssets;
 
+    private $statusCallbackUrl;
+
+    private $statusCallbackHeaders;
+
     public function __construct($array = [])
     {
         $this->fromArray($array);
@@ -43,7 +49,9 @@ class UnmanagedDcmBlob implements BlobInterface
         return [
             self::PUBLICATION_ID => $this->publicationId,
             self::GOOGLE_ADVERTISER_ID => $this->advertiserId,
-            self::CREATIVE_ASSETS => $assets
+            self::CREATIVE_ASSETS => $assets,
+            self::STATUS_CALLBACK_URL => $this->statusCallbackUrl,
+            self::STATUS_CALLBACK_HEADERS => $this->statusCallbackHeaders
         ];
     }
 
@@ -52,6 +60,8 @@ class UnmanagedDcmBlob implements BlobInterface
         $this->publicationId = $this->safeGet($array, self::PUBLICATION_ID);
         $this->advertiserId = $this->safeGet($array, self::GOOGLE_ADVERTISER_ID);
         $assets = $this->safeGet($array, self::CREATIVE_ASSETS, []);
+        $this->statusCallbackUrl = $this->safeGet($array, self::STATUS_CALLBACK_URL);
+        $this->statusCallbackHeaders = $this->safeGet($array, self::STATUS_CALLBACK_HEADERS);
 
         $this->creativeAssets = [];
         foreach($assets as $assetArray) {
@@ -105,5 +115,37 @@ class UnmanagedDcmBlob implements BlobInterface
     public function getPublicationId()
     {
         return $this->publicationId;
+    }
+
+    /**
+     * @param mixed $callbackHeaders
+     */
+    public function setStatusCallbackHeaders($callbackHeaders)
+    {
+        $this->statusCallbackHeaders = $callbackHeaders;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getStatusCallbackHeaders()
+    {
+        return $this->statusCallbackHeaders;
+    }
+
+    /**
+     * @param mixed $callbackUrl
+     */
+    public function setStatusCallbackUrl($callbackUrl)
+    {
+        $this->statusCallbackUrl = $callbackUrl;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getStatusCallbackUrl()
+    {
+        return $this->statusCallbackUrl;
     }
 } 

--- a/test/phpunit/src/PaperG/FirehoundBlob/Dcm/UnmanagedDcmBlobTest.php
+++ b/test/phpunit/src/PaperG/FirehoundBlob/Dcm/UnmanagedDcmBlobTest.php
@@ -5,6 +5,7 @@ namespace PaperG\Common\Test\Dcm;
 
 use PaperG\FirehoundBlob\Dcm\DcmCreativeAsset;
 use PaperG\FirehoundBlob\Dcm\UnmanagedDcmBlob;
+use PaperG\FirehoundBlob\Facebook\UnmanagedFacebookBlob;
 
 class UnmanagedDcmBlobTest extends \FirehoundBlobTestCase
 {
@@ -23,17 +24,31 @@ class UnmanagedDcmBlobTest extends \FirehoundBlobTestCase
                 $mockCreativeAssetArray
             ]
         ];
-
+        $mockCallbackUrl = 'mock callback url';
+        $mockAdvId = 'mock adv id';
+        $mockPublicationId = 'mock pub id';
+        $mockHeaders = ['mock headers'];
+        $testArray[UnmanagedDcmBlob::STATUS_CALLBACK_URL] = $mockCallbackUrl;
+        $testArray[UnmanagedDcmBlob::GOOGLE_ADVERTISER_ID] = $mockAdvId;
+        $testArray[UnmanagedDcmBlob::PUBLICATION_ID] = $mockPublicationId;
+        $testArray[UnmanagedDcmBlob::STATUS_CALLBACK_HEADERS] = $mockHeaders;
         $sut->fromArray($testArray);
         $assets = $sut->getCreativeAssets();
         $asset = $assets[0];
-        $this->assertEquals($mockAdTag,$asset->getAdTag());
-
+        $this->assertEquals($mockAdTag, $asset->getAdTag());
+        $this->assertEquals($mockCallbackUrl, $sut->getStatusCallbackUrl());
+        $this->assertEquals($mockAdvId, $sut->getAdvertiserId());
+        $this->assertEquals($mockPublicationId, $sut->getPublicationId());
+        $this->assertEquals($mockHeaders, $sut->getStatusCallbackHeaders());
         $array = $sut->toArray();
 
         $this->assertEquals(
             $testArray[UnmanagedDcmBlob::CREATIVE_ASSETS][0][DcmCreativeAsset::AD_TAG],
             $array[UnmanagedDcmBlob::CREATIVE_ASSETS][0][DcmCreativeAsset::AD_TAG]
         );
+        $this->assertEquals($mockCallbackUrl, $array[UnmanagedDcmBlob::STATUS_CALLBACK_URL]);
+        $this->assertEquals($mockAdvId, $array[UnmanagedDcmBlob::GOOGLE_ADVERTISER_ID]);
+        $this->assertEquals($mockPublicationId, $array[UnmanagedDcmBlob::PUBLICATION_ID]);
+        $this->assertEquals($mockHeaders, $array[UnmanagedDcmBlob::STATUS_CALLBACK_HEADERS]);
     }
 } 


### PR DESCRIPTION
This commit adds statusCallbackUrl and statusCallbackHeaders to UnmanagedDcmBlob
which will inform Firehound where to send status updates.