### PR TITLE
Add Facebook Ad Types

### DIFF
--- a/src/PaperG/FirehoundBlob/CampaignData/Context.php
+++ b/src/PaperG/FirehoundBlob/CampaignData/Context.php
@@ -28,6 +28,7 @@ class Context
     CONST AUDIENCE_GROUPS            = "audienceGroups"; //CampaignAudienceGroups
     CONST APPNEXUS_OBJECT_INCLUSIONS = "appnexusObjectInclusions"; //an AppNexus specific component to specify which objects to update
     CONST FACEBOOK_CONTEXT          = "facebookContext";
+    const FACEBOOK_AD_TYPE          = 'facebookAdType';
 
     //These are values used mostly by AppNexus
     CONST PUBLICATION_NAME          = "publicationName"; //string

--- a/src/PaperG/FirehoundBlob/Facebook/Values/FacebookAdType.php
+++ b/src/PaperG/FirehoundBlob/Facebook/Values/FacebookAdType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PaperG\FirehoundBlob\Facebook\Values;
+
+class FacebookAdType
+{
+    const CAROUSEL = 'carousel';
+    const LINK = 'link';
+}


### PR DESCRIPTION
This commit:
* Adds a new Context constant to support ad types for managed Facebook
* Adds FacebookAdTypes to help define the ad types supported for
Facebook