### PR TITLE
FacebookCreativeData isValid()

### DIFF
--- a/src/PaperG/FirehoundBlob/Facebook/FacebookCreativeData.php
+++ b/src/PaperG/FirehoundBlob/Facebook/FacebookCreativeData.php
@@ -237,4 +237,10 @@ class FacebookCreativeData implements BlobInterface
         $this->description = $this->safeGet($array, self::DESCRIPTION);
         $this->variationId = $this->safeGet($array, self::VARIATION_ID);
     }
+
+    //No validation yet
+    public function isValid()
+    {
+        return true;
+    }
 } 


### PR DESCRIPTION
We need an isValid function on FacebookCreativeData to work with
FirehoundBlob.