### PR TITLE
Facebook - Add Campaign Objective

### DIFF
--- a/src/PaperG/FirehoundBlob/CampaignData/Context/FacebookContext.php
+++ b/src/PaperG/FirehoundBlob/CampaignData/Context/FacebookContext.php
@@ -3,19 +3,24 @@ namespace PaperG\FirehoundBlob\CampaignData\Context;
 
 
 use PaperG\FirehoundBlob\Facebook\FacebookAdSet;
+use PaperG\FirehoundBlob\Utility;
 
 class FacebookContext
 {
+    use Utility;
+
     const AD_ACCOUNT_ID = "adAccountId";
     const AD_SETS = "adSets";
     const PAGE_ID = "pageId";
     const ACCESS_TOKEN = "accessToken";
     const IG_ACTOR_ID = "igActorId";
+    const CAMPAIGN_OBJECTIVE = "campaignObjective";
 
     private $adAccountId = null;
     private $pageId = null;
     private $accessToken = null;
     private $igActorId = null;
+    private $campaignObjective = null;
 
     /**
      * @var FacebookAdSet[]
@@ -75,6 +80,16 @@ class FacebookContext
         return $this->adSets;
     }
 
+    public function setCampaignObjective($objective)
+    {
+        $this->campaignObjective = $objective;
+    }
+
+    public function getCampaignObjective()
+    {
+        return $this->campaignObjective;
+    }
+
     public function toAssociativeArray()
     {
         $adSets = array();
@@ -88,16 +103,18 @@ class FacebookContext
             self::AD_SETS => $adSets,
             self::PAGE_ID => $this->pageId,
             self::ACCESS_TOKEN => $this->accessToken,
-            self::IG_ACTOR_ID => $this->igActorId
+            self::IG_ACTOR_ID => $this->igActorId,
+            self::CAMPAIGN_OBJECTIVE => $this->campaignObjective
         );
     }
 
     public function fromAssociativeArray($array)
     {
-        $this->adAccountId = isset($array[self::AD_ACCOUNT_ID]) ? $array[self::AD_ACCOUNT_ID] : null;
-        $this->pageId = isset($array[self::PAGE_ID]) ? $array[self::PAGE_ID] : null;
-        $this->accessToken = isset($array[self::ACCESS_TOKEN]) ? $array[self::ACCESS_TOKEN] : null;
-        $this->igActorId = isset($array[self::IG_ACTOR_ID]) ? $array[self::IG_ACTOR_ID] : null;
+        $this->adAccountId = $this->safeGet($array, self::AD_ACCOUNT_ID);
+        $this->pageId = $this->safeGet($array, self::PAGE_ID);
+        $this->accessToken = $this->safeGet($array, self::ACCESS_TOKEN);
+        $this->igActorId = $this->safeGet($array, self::IG_ACTOR_ID);
+        $this->campaignObjective = $this->safeGet($array, self::CAMPAIGN_OBJECTIVE);
 
         $adSets = array();
         if (isset($array[self::AD_SETS])) {

--- a/src/PaperG/FirehoundBlob/Facebook/UnmanagedFacebookBlob.php
+++ b/src/PaperG/FirehoundBlob/Facebook/UnmanagedFacebookBlob.php
@@ -29,6 +29,7 @@ class UnmanagedFacebookBlob implements BlobInterface
     const PUBLICATION_NAME = 'publicationName';
     const IG_ACTOR_ID = 'igActorId';
     const VERSION = 'version';
+    const CAMPAIGN_OBJECTIVE = 'campaignObjective';
 
     const CURRENT_VERSION = 1;
 
@@ -106,6 +107,11 @@ class UnmanagedFacebookBlob implements BlobInterface
      * @var string
      */
     private $igActorId;
+
+    /**
+     * @var string
+     */
+    private $campaignObjective;
 
     public function __construct($array = null)
     {
@@ -352,23 +358,24 @@ class UnmanagedFacebookBlob implements BlobInterface
     public function toArray()
     {
         $array  = [
-            self::STATUS                => $this->status,
-            self::START_DATE            => $this->startDate,
-            self::END_DATE              => $this->endDate,
-            self::GEOGRAPHIC_TARGETING  => isset($this->geographicTargeting)
+            self::STATUS => $this->status,
+            self::START_DATE => $this->startDate,
+            self::END_DATE => $this->endDate,
+            self::GEOGRAPHIC_TARGETING => isset($this->geographicTargeting)
                     ? $this->geographicTargeting->toArray() : null,
             self::DEMOGRAPHIC_TARGETING => isset($this->demographicTargeting)
                     ? $this->demographicTargeting->toArray() : null,
-            self::AUDIENCE_TARGETING    => isset($this->audienceTargeting)
+            self::AUDIENCE_TARGETING => isset($this->audienceTargeting)
                     ? $this->audienceTargeting->toArray() : null,
-            self::OBJECTS_TO_UPDATE     => $this->objectsToUpdate,
-            self::AD_ACCOUNT_ID         => $this->adAccountId,
-            self::PAGE_ID               => $this->pageId,
-            self::ACCESS_TOKEN          => $this->accessToken,
-            self::BUDGET                => isset($this->budget) ? $this->budget->toArray() : null,
-            self::PUBLICATION_NAME      => $this->publicationName,
-            self::IG_ACTOR_ID           => $this->igActorId,
-            self::VERSION               => self::CURRENT_VERSION
+            self::OBJECTS_TO_UPDATE => $this->objectsToUpdate,
+            self::AD_ACCOUNT_ID => $this->adAccountId,
+            self::PAGE_ID => $this->pageId,
+            self::ACCESS_TOKEN => $this->accessToken,
+            self::BUDGET => isset($this->budget) ? $this->budget->toArray() : null,
+            self::PUBLICATION_NAME => $this->publicationName,
+            self::IG_ACTOR_ID => $this->igActorId,
+            self::CAMPAIGN_OBJECTIVE => $this->campaignObjective,
+            self::VERSION => self::CURRENT_VERSION
         ];
         $adSets = null;
         if (!empty($this->adSets)) {
@@ -445,5 +452,6 @@ class UnmanagedFacebookBlob implements BlobInterface
             $this->budget  = $budget;
         }
         $this->publicationName = $this->safeGet($array, self::PUBLICATION_NAME);
+        $this->campaignObjective = $this->safeGet($array, self::CAMPAIGN_OBJECTIVE);
     }
 }

--- a/src/PaperG/FirehoundBlob/Facebook/Values/FacebookCampaignObjectives.php
+++ b/src/PaperG/FirehoundBlob/Facebook/Values/FacebookCampaignObjectives.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PaperG\FirehoundBlob\Facebook\Values;
+
+class FacebookCampaignObjectives
+{
+    const BRAND_AWARENESS = "brandAwareness";
+    const LINK_CLICKS = "linkClicks";
+} 

--- a/test/phpunit/src/PaperG/FirehoundBlob/Context/FacebookContextTest.php
+++ b/test/phpunit/src/PaperG/FirehoundBlob/Context/FacebookContextTest.php
@@ -52,7 +52,8 @@ class FacebookContextTest extends FirehoundBlobTestCase
                 $mockAdSetArray
             ),
             FacebookContext::ACCESS_TOKEN => null,
-            FacebookContext::IG_ACTOR_ID => $mockIgActorId
+            FacebookContext::IG_ACTOR_ID => $mockIgActorId,
+            FacebookContext::CAMPAIGN_OBJECTIVE => null
         );
         $associativeArray = $facebookContext->toAssociativeArray();
         $this->assertEquals($expectedArray, $associativeArray);


### PR DESCRIPTION
This commit adds campaign objective as an field to FacebookContext
and UnmanagedFacebookBlob.  This allows us to support campaign objective for
PlaceLocal and Firehound.

PL-22428