### PR TITLE
Creative Json Fix

### DIFF
--- a/src/PaperG/FirehoundBlob/Schema/CampaignData/creative.json
+++ b/src/PaperG/FirehoundBlob/Schema/CampaignData/creative.json
@@ -2,10 +2,18 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "properties": {
-        "adtagJavascriptSecure": {"type": ["string", "null"]},
-        "adtagJavascriptInsecure":{"type": ["string", "null"]},
-        "adtagIframeSecure":{"type": ["string", "null"]},
-        "adtagIframeInsecure":{"type": ["string", "null"]},
+        "adtagJavascriptSecure": {
+            "type": ["object", "null"]
+        },
+        "adtagJavascriptInsecure":{
+            "type": ["object", "null"]
+        },
+        "adtagIframeSecure":{
+            "type": ["object", "null"]
+        },
+        "adtagIframeInsecure":{
+            "type": ["object", "null"]
+        },
         "mediaUrl":{"type": ["string", "null"]},
         "callToAction":{"type": ["string", "null"]},
         "message":{"type": ["string", "null"]},

--- a/test/phpunit/src/PaperG/FirehoundBlob/AppNexus/Validators/AppNexusBlobValidatorTest.php
+++ b/test/phpunit/src/PaperG/FirehoundBlob/AppNexus/Validators/AppNexusBlobValidatorTest.php
@@ -59,8 +59,10 @@ class AppNexusBlobValidatorTest extends \FirehoundBlobTestCase
                 AppNexusBidSettingFields::BID_TYPE => "predicted"
             ],
             AppNexusBlobFields::CREATIVE => [
-                CreativeBlobFields::ADTAG_JAVASCRIPT_SECURE => '',
-                CreativeBlobFields::ADTAG_JAVASCRIPT_INSECURE => ''
+                CreativeBlobFields::ADTAG_JAVASCRIPT_SECURE => [
+                    "medium_rectangle" => "ad tag"
+                ],
+                CreativeBlobFields::ADTAG_JAVASCRIPT_INSECURE => null
             ]
         ];
         $anBlob = new AppNexusBlob($array);


### PR DESCRIPTION
We had a bug where the json for the Creative object was incorrect.

This commit fixes it.  Basically, the adtag secure/inscure stuff
is supposed to point at an associative array of dimension name
to ad tag.

PL-22278