### PR TITLE
Add ManagedFacebookBlob to ScenarioBlob

### DIFF
--- a/src/PaperG/FirehoundBlob/ScenarioBlob.php
+++ b/src/PaperG/FirehoundBlob/ScenarioBlob.php
@@ -4,6 +4,7 @@ namespace PaperG\FirehoundBlob;
 
 use PaperG\FirehoundBlob\AppNexus\AppNexusBlob;
 use PaperG\FirehoundBlob\Dcm\UnmanagedDcmBlob;
+use PaperG\FirehoundBlob\Facebook\ManagedFacebookBlob;
 use PaperG\FirehoundBlob\Facebook\UnmanagedFacebookBlob;
 
 class ScenarioBlob implements BlobInterface
@@ -70,6 +71,9 @@ class ScenarioBlob implements BlobInterface
         switch ($scenario) {
             case Scenario::FB_UNMANAGED:
                 $this->blob = new UnmanagedFacebookBlob($blobArray);
+                break;
+            case Scenario::FB_MANAGED:
+                $this->blob = new ManagedFacebookBlob($blobArray);
                 break;
             case Scenario::DCM_UNMANAGED:
                 $this->blob = new UnmanagedDcmBlob($blobArray);


### PR DESCRIPTION
We previously weren't converting ManagedFacebookBlobs in ScenarioBlob.  This
commit makes us do so.

PL-22576