### PR TITLE
Allow Customization Names

### DIFF
--- a/src/PaperG/FirehoundBlob/Schema/AppNexus/appNexusBlob.json
+++ b/src/PaperG/FirehoundBlob/Schema/AppNexus/appNexusBlob.json
@@ -18,16 +18,7 @@
         "budget": {"$ref": "#/definitions/budget"},
         "campaignId": {"type": "number"},
         "creative": {"$ref": "#/definitions/creative"},
-        "customizationName":{
-            "oneOf": [
-                {
-                    "type":{
-                        "enum":["YPG", "DEX", ""]
-                    }
-                },
-                {"type": "null"}
-            ]
-        },
+        "customizationName":{"type": ["string", "null"]},
         "daypartTargeting": {"$ref": "#/definitions/daypartTargeting"},
         "endDate":{"type": "number"},
         "geographicTargeting":{"$ref": "#/definitions/geotargeting"},


### PR DESCRIPTION
Someone added customization names to a bunch of publishers, which was
not expected for validation.  This commit stops checking for specific
values for customization_name.