### PR TITLE
Add FacebookAudienceTargetingTypes

### DIFF
--- a/src/PaperG/FirehoundBlob/Facebook/Values/FacebookAudienceTargetingTypes.php
+++ b/src/PaperG/FirehoundBlob/Facebook/Values/FacebookAudienceTargetingTypes.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PaperG\FirehoundBlob\Facebook\Values;
+
+class FacebookAudienceTargetingTypes
+{
+    const FACEBOOK = 'fb_ids';
+    const PLACELOCAL = 'pl_ids';
+} 


### PR DESCRIPTION
This commit adds a new class containing 'fb_ids' and 'pl_ids' as
values for FacebookAudienceTargeting->types.

PL-26831